### PR TITLE
Some modifications to path handling and directory display

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "0.1.2"
+version = "0.1.3"
 name = "bcat"
 authors = ["bootjp / Yoshiaki Ueda <contact@bootjp.me>"]
 edition = "2018"


### PR DESCRIPTION
- default list directory order is a case insensitive filename ascending order.
- path is canonicalized.
- list directory is displayed only the file name