### PR TITLE
fix: deprecated `chrono::TimeZone::timestamp`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ prettytable-rs = "0.10.0"
 result = "1.0.0"
 structopt = "0.3.26"
 unix_mode = "0.1.4"
-use = "0.0.0"
 users = "0.11.0"
 
 [dev-dependencies]


### PR DESCRIPTION
replace timestamp with `timestamp_opt`
remove "use" from Cargo.toml
handle case where timestamp isn't valid
 - returns local time now instead
 - NOTE: alternative could print to stderr, but might break existing use cases.